### PR TITLE
fix(ci): use bash shell for Windows deno compile step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         run: cargo install tauri-cli --version "^1"
 
       - name: Compile EventBox server
+        shell: bash
         run: |
           deno compile --no-check \
             --allow-net --allow-read --allow-write --allow-env --allow-ffi \


### PR DESCRIPTION
PowerShell on Windows does not support backslash line continuation. Force `shell: bash` for the compile step so it works on all platforms.

**Link to Devin session:** https://app.devin.ai/sessions/b130bdd044f04386a31f8c8f67109c53
**Requested by:** Joseph Paredes (@nightcrawlerxme)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
