### PR TITLE
chore: friendly download links in README and friendly asset names in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,33 +61,24 @@ jobs:
       - name: Build Tauri app
         run: cd src-tauri && cargo tauri build
 
-      - name: Upload artifacts (Linux .deb)
-        if: matrix.platform == 'ubuntu-22.04'
-        uses: actions/upload-artifact@v4
-        with:
-          name: EventBox-linux-deb
-          path: src-tauri/target/release/bundle/deb/*.deb
+      - name: Rename artifacts to friendly names
+        shell: bash
+        run: |
+          mkdir -p dist
+          if [ "${{ matrix.platform }}" = "ubuntu-22.04" ]; then
+            cp src-tauri/target/release/bundle/deb/*.deb dist/EventBox-Linux.deb
+            cp src-tauri/target/release/bundle/appimage/*.AppImage dist/EventBox-Linux.AppImage
+          elif [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            cp src-tauri/target/release/bundle/msi/*.msi dist/EventBox-Windows.msi
+          elif [ "${{ matrix.platform }}" = "macos-latest" ]; then
+            cp src-tauri/target/release/bundle/dmg/*.dmg dist/EventBox-Mac.dmg
+          fi
 
-      - name: Upload artifacts (Linux .AppImage)
-        if: matrix.platform == 'ubuntu-22.04'
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: EventBox-linux-appimage
-          path: src-tauri/target/release/bundle/appimage/*.AppImage
-
-      - name: Upload artifacts (Windows .msi)
-        if: matrix.platform == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: EventBox-windows-msi
-          path: src-tauri/target/release/bundle/msi/*.msi
-
-      - name: Upload artifacts (macOS .dmg)
-        if: matrix.platform == 'macos-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: EventBox-macos-dmg
-          path: src-tauri/target/release/bundle/dmg/*.dmg
+          name: EventBox-${{ matrix.platform }}
+          path: dist/*
 
   release:
     needs: build

--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@ No terminal. No dependencies. Just download, install, and go.
 
 ## Download & Install
 
-Go to the [Releases](https://github.com/W-A-I-T/EventBox/releases) page and download the installer for your platform:
-
-| Platform | File | How to Install |
-|----------|------|----------------|
-| **Windows** | `EventBox_x.x.x_x64_en-US.msi` | Double-click the `.msi` file |
-| **macOS** | `EventBox_x.x.x_aarch64.dmg` | Open the `.dmg`, drag EventBox to Applications |
-| **Linux** | `event-box_x.x.x_amd64.deb` | `sudo dpkg -i event-box_*.deb` or double-click |
-| **Linux** | `event-box_x.x.x_amd64.AppImage` | Right-click > Properties > Permissions > Allow executing, then double-click |
+| Platform | Download | How to Install |
+|----------|----------|----------------|
+| **Windows** | [EventBox-Windows.msi](https://github.com/W-A-I-T/EventBox/releases/latest/download/EventBox-Windows.msi) | Double-click the `.msi` file |
+| **macOS** | [EventBox-Mac.dmg](https://github.com/W-A-I-T/EventBox/releases/latest/download/EventBox-Mac.dmg) | Open the `.dmg`, drag EventBox to Applications |
+| **Linux (.deb)** | [EventBox-Linux.deb](https://github.com/W-A-I-T/EventBox/releases/latest/download/EventBox-Linux.deb) | `sudo dpkg -i EventBox-Linux.deb` or double-click |
+| **Linux (AppImage)** | [EventBox-Linux.AppImage](https://github.com/W-A-I-T/EventBox/releases/latest/download/EventBox-Linux.AppImage) | Right-click → Properties → Permissions → Allow executing, then double-click |
 
 > **Everything is bundled.** No Deno, no Rust, no Node.js needed on the user's machine.
 
@@ -143,7 +141,7 @@ EventBox/
 │       ├── server.ts           # EventBox LAN server source
 │       └── eventbox-server*    # Compiled server binary (built during build)
 ├── src/
-│   └── dashboard.html          # Dashboard UI (room code, QR, IPs, controls)
+│   └── index.html               # Dashboard UI (room code, QR, IPs, controls)
 ├── package.json                # Build scripts
 ├── .gitignore
 ├── LICENSE                     # GPL-3.0


### PR DESCRIPTION
- README: Direct download links with friendly names (EventBox-Windows.msi, EventBox-Mac.dmg, EventBox-Linux.deb, EventBox-Linux.AppImage)
- README: Fix architecture section (dashboard.html → index.html)
- CI: Rename build artifacts to friendly names before upload so future releases have clean asset names

**Link to Devin session:** https://app.devin.ai/sessions/b130bdd044f04386a31f8c8f67109c53
**Requested by:** Joseph Paredes (@nightcrawlerxme)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
