### PR TITLE
fix: move /state/ref handler into switch block to fix unreachable endpoint

### DIFF
--- a/src-tauri/resources/server.ts
+++ b/src-tauri/resources/server.ts
@@ -912,6 +912,17 @@ h1{margin:0 0 .25rem;font-size:1.5rem;color:#fff}
         return json({ event_id: EVENT_ID, results: rows });
       }
 
+      case "ref": {
+        const table = url.searchParams.get("table") || "";
+        if (!table) return json({ error: "table param required" }, 400);
+        const rows = queryRows(
+          `SELECT data_json, fetched_at FROM ref_data WHERE event_id=? AND table_name=?`,
+          [EVENT_ID, table],
+        );
+        if (rows.length === 0) return json({ data: null });
+        return json({ data: rows[0][0], fetched_at: rows[0][1] });
+      }
+
       default:
         return json({ error: `unknown state kind: ${kind}` }, 404);
     }
@@ -1796,19 +1807,7 @@ setInterval(loadData,10000);
     return new Response(html, { headers: { "content-type": "text/html" } });
   }
 
-  // ---- GET /state/ref — Serve ref_data from SQLite ----
-  if (url.pathname === "/state/ref" && req.method === "GET") {
-    const claims = await authenticate(req);
-    if (!claims) return json({ error: "unauthorized" }, 401);
-    const table = url.searchParams.get("table") || "";
-    if (!table) return json({ error: "table param required" }, 400);
-    const rows = queryRows(
-      `SELECT data_json, fetched_at FROM ref_data WHERE event_id=? AND table_name=?`,
-      [EVENT_ID, table],
-    );
-    if (rows.length === 0) return json({ data: null });
-    return json({ data: rows[0][0], fetched_at: rows[0][1] });
-  }
+  // /state/ref is now handled inside the /state/* switch block above
 
   // ---- /app/* catch-all: redirect to local portal or cloud ----
   if (url.pathname.startsWith("/app/")) {


### PR DESCRIPTION
# fix: move /state/ref handler into switch block to fix unreachable endpoint

## Summary

The `GET /state/ref` endpoint was **unreachable**. The `/state/*` routing block (line ~811) uses `url.pathname.startsWith("/state/")` which intercepts all `/state/*` requests, including `/state/ref`. Since the switch block had no `case "ref"`, the `default` case returned a 404 (`unknown state kind: ref`) before the standalone handler at line ~1799 could ever execute.

**Fix:** Added `case "ref"` to the existing `/state/*` switch block (before `default`), and removed the dead standalone handler. The query logic is identical. Auth is already handled at the top of the `/state/*` block, so there is no auth regression.

This aligns EventBox with `dance-flow-control`, which already has `case "ref"` in the switch block.

## Review & Testing Checklist for Human

- [ ] **Verify `/state/ref` actually works end-to-end**: sync some ref data via `POST /api/sync-ref`, then hit `GET /state/ref?table=<name>` with a valid token and confirm you get the data back (this endpoint was broken before, so it has likely never been tested in EventBox)
- [ ] **Confirm the scanner portal loads credential data**: the scanner portal fetches `/state/ref?table=credentials` — verify check-in flow works after this fix
- [ ] **Confirm no other `/state/*` routes regressed**: spot-check `/state/checkins`, `/state/heats`, `/state/marshal` still return expected data

### Notes
- No automated test suite exists for this server, so manual verification is required
- This is a **bug fix only** — no new functionality added
- Requested by: @nightcrawlerxme
- Session: https://app.devin.ai/sessions/fe83b77e24424000b3845bd213ac5261
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
