### PR TITLE
fix: queryRows returns objects instead of arrays, breaking /state/ref data retrieval

### DIFF
--- a/src-tauri/resources/server.ts
+++ b/src-tauri/resources/server.ts
@@ -183,7 +183,8 @@ function queryRows(sql: string, params: unknown[] = []): unknown[][] {
   const stmt = db.prepare(sql);
   const rows: unknown[][] = [];
   for (const row of stmt.iter(...params)) {
-    rows.push(row as unknown[]);
+    // stmt.iter() returns objects with named columns; convert to value arrays
+    rows.push(Object.values(row as Record<string, unknown>));
   }
   return rows;
 }


### PR DESCRIPTION
## Summary

`queryRows()` uses `stmt.iter()` from `@db/sqlite@0.12`, which returns **objects with named columns** (e.g., `{data_json: "...", fetched_at: "..."}`), not arrays. The previous code simply cast these objects via `as unknown[]`, which is a no-op at runtime — the rows remained objects.

This caused **all positional access** (e.g., `rows[0][0]`) to return `undefined`, and **all array destructuring** (e.g., `.map(([col1, col2]) => ...)`) to throw at runtime when rows contained data. The most visible symptom was `/state/ref` returning `{}` instead of actual ref data, since `JSON.stringify({ data: undefined, fetched_at: undefined })` produces `{}`.

The fix converts each row to a value array via `Object.values()`, which preserves column order as specified in the SELECT statement.

## Review & Testing Checklist for Human

- [ ] **Verify `Object.values()` column ordering**: The fix relies on `Object.values()` returning properties in the order the SQLite driver inserts them (i.e., matching the SELECT column order). Confirm this holds for `@db/sqlite@0.12` — if the driver ever returns columns in a different order, positional indexing silently breaks.
- [ ] **Test all `/state/*` endpoints with actual data**: The automated test only verified `/state/ref`. Endpoints like `/state/checkins`, `/state/marshal`, `/state/heats`, `/state/scores`, and `/state/nowplaying` all use `queryRows` with `.map()` array destructuring — populate data and confirm they return correct results.
- [ ] **Propagate this fix to `dance-flow-control`**: `public/eventbox/server.ts` has the identical bug at line 175-182. Without fixing it there, the next CI sync will overwrite this fix.

### Suggested manual test
```bash
# Start server
EVENTBOX_EVENT_ID=test EVENTBOX_PORT=8787 deno run --allow-all server.ts

# Get token
TOKEN=$(curl -s -X POST localhost:8787/auth/token \
  -H "Content-Type: application/json" \
  -d '{"room_code":"<code>","device_id":"d1","role":"event_admin"}' | jq -r .token)

# Sync ref data, then read it back
curl -s -X POST localhost:8787/api/sync-ref \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"tables":[{"name":"creds","data":[{"id":"1","name":"Alice"}]}]}'

curl -s localhost:8787/state/ref?table=creds -H "Authorization: Bearer $TOKEN"
# Expected: {"data":"[...]","fetched_at":"..."}  — NOT {}
```

### Notes
- [Devin Session](https://app.devin.ai/sessions/fe83b77e24424000b3845bd213ac5261)
- Requested by: @nightcrawlerxme
- This bug was discovered during end-to-end testing of PR #6 (the `/state/ref` routing fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
