### PR TITLE
fix: fix YAML syntax error in auto-release workflow + add manual dispatch

### DIFF
--- a/.github/workflows/auto-release-on-sync.yml
+++ b/.github/workflows/auto-release-on-sync.yml
@@ -5,11 +5,14 @@ name: Auto-release on sync
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   auto-tag:
-    # Only run for auto-sync commits (prevents infinite loops from the version bump commit)
-    if: startsWith(github.event.head_commit.message, 'chore: auto-sync')
+    # Only run for auto-sync commits OR manual dispatch (prevents infinite loops from the version bump commit)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'chore: auto-sync')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -65,7 +68,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
           if ! git diff --cached --quiet; then
             git commit -m "chore: bump version to ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary

All runs of the `auto-release-on-sync.yml` workflow have been failing with **"This run likely failed because of a workflow file issue"** because of a YAML syntax error introduced in PR #12.

**Root cause:** The `if:` condition on line 12 contained `'chore: auto-sync'` — the colon-space inside the single-quoted string is interpreted by the YAML parser as a mapping separator, making the entire workflow file unparseable. Every push to `main` (including the PR #12 merge) triggered a workflow run that immediately failed at the YAML parsing stage before any job could execute.

**Fix:** Use a YAML block scalar (`>-`) to properly quote the multi-line expression, avoiding the colon ambiguity.

Also:
- Added `workflow_dispatch` trigger so the auto-release can be run manually
- Removed a duplicate `git add` line

## Review & Testing Checklist for Human

- [ ] **Do NOT use manual dispatch to create v0.3.0.** The workflow computes the next version from the latest git tag (`v0.2.0`), so dispatching now would create `v0.2.1` and **overwrite** the 0.3.0 already in your project files. Instead, create the v0.3.0 release by pushing the tag directly:
  ```bash
  git checkout main && git pull
  git tag v0.3.0
  git push origin v0.3.0
  ```
  This triggers the existing `build.yml` (which fires on `v*` tags) and creates the v0.3.0 release. After that, future auto-syncs and manual dispatches will correctly compute v0.3.1+.
- [ ] **After merging, verify the workflow YAML is valid** by checking that the next push to `main` no longer shows "workflow file issue" failures in [Actions](https://github.com/W-A-I-T/EventBox/actions).
- [ ] **Test the full auto-release pipeline end-to-end**: after tagging v0.3.0, push a change to a synced file in `dance-flow-control` → confirm sync PR lands on EventBox → confirm a new tag (v0.3.1) and release are created automatically.

### Notes
- The `workflow_dispatch` trigger bypasses the commit-message filter, which is intentional for manual releases. It still goes through the same version-bump-and-tag logic.
- Requested by: @nightcrawlerxme
- [Link to Devin Session](https://app.devin.ai/sessions/98f2d760bd1a4b46b4fd24b4dcf445ac)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
