### PR TITLE
fix: resolve Rust borrow error in start_server that breaks macOS/Linux builds

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,7 +66,6 @@ fn start_server(state: &Mutex<ServerState>, app: &tauri::AppHandle) -> Result<()
             // Read stdout in background to capture room code
             if let Some(stdout) = child.stdout.take() {
                 let app_handle = app.clone();
-                let state_ref = app.state::<Mutex<ServerState>>();
                 std::thread::spawn(move || {
                     let reader = BufReader::new(stdout);
                     for line in reader.lines().map_while(Result::ok) {
@@ -76,6 +75,7 @@ fn start_server(state: &Mutex<ServerState>, app: &tauri::AppHandle) -> Result<()
                             if let Some(code) = line.split("Room code:").nth(1) {
                                 let code = code.trim().to_string();
                                 {
+                                    let state_ref = app_handle.state::<Mutex<ServerState>>();
                                     let mut s = state_ref.lock().unwrap();
                                     s.room_code = Some(code.clone());
                                 }


### PR DESCRIPTION
## Summary

Fixes the Rust compile error **"borrowed data escapes outside of function"** that breaks the macOS (and possibly Linux) builds in the `Build & Release` workflow.

The bug was introduced when `Arc<Mutex<ServerState>>` was replaced with Tauri-managed `Mutex<ServerState>`. The old code used `Arc::clone(state)` to share state into the spawned thread; the replacement called `app.state()` **outside** the `move` closure, producing a borrowed `State<'_>` tied to `app`'s lifetime that cannot be moved into the thread.

**Fix:** Move the `.state()` call inside the closure, using the already-cloned owned `app_handle` instead of the borrowed `app`.

## Review & Testing Checklist for Human

- [ ] **Verify the fix compiles on all three platforms.** I was unable to build the Tauri project locally — this needs CI confirmation. The logic is straightforward (owned `AppHandle` → `.state()` inside thread) but a green macOS build is the real proof.
- [ ] **Linux build may still fail independently.** The v0.3.0 `Build & Release` also showed `webkit2gtk::Settings` method-not-found errors on `ubuntu-22.04` that are unrelated to this code change — they appear to be from a CI runner image update changing system `libwebkit2gtk-4.0-dev` headers. This PR does **not** address that.
- [ ] **Apply the same fix to `dance-flow-control`** at `desktop/src-tauri/src/main.rs` line 69. That repo is the source of truth and the sync workflow will overwrite EventBox's `main.rs` on the next sync, reintroducing the bug if not fixed upstream.

### Notes
- The `state_ref` is now obtained per-iteration (each time a "Room code:" line is parsed) rather than captured once before the thread starts. This is functionally equivalent since `app_handle.state()` returns the same Tauri-managed instance each time.
- Requested by: @nightcrawlerxme
- [Link to Devin Session](https://app.devin.ai/sessions/98f2d760bd1a4b46b4fd24b4dcf445ac)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
