### PR TITLE
fix: pin Rust 1.85 on Linux to fix webkit2gtk SettingsExt build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      # Pin Rust 1.79 on Linux: newer compilers break wry 0.24 due to
+      # Pin Rust 1.85 on Linux: newer compilers break wry 0.24 due to
       # a glob-import trait-name collision between gtk::prelude::SettingsExt
       # and webkit2gtk::SettingsExt (see issue #18).
       - name: Install Rust 1.85 for project build (Linux)


### PR DESCRIPTION
# fix: pin Rust 1.85 on Linux to fix webkit2gtk SettingsExt build failure

## Summary

The `ubuntu-22.04` GitHub Actions runner now ships `libwebkit2gtk-4.0-dev` **2.50.4**. Combined with recent Rust compilers (stable ≥1.86), this causes 7 `E0599` "no method found" errors when compiling `wry 0.24` (Tauri v1). The methods exist on the `webkit2gtk::SettingsExt` trait, but both `gtk::prelude::*` and `webkit2gtk::traits::*` export a trait named `SettingsExt`, and newer Rust compilers treat this glob-import name collision as ambiguous — preventing trait method resolution.

This PR uses a **two-toolchain approach** on Linux:
1. **Stable Rust** is installed as the default toolchain (used for `cargo install tauri-cli`).
2. **Rust 1.85.0** is installed additionally and used only for the `cargo tauri build` step via `RUSTUP_TOOLCHAIN` env var override.

macOS and Windows continue using `stable` for all steps.

**Why 1.85.0?** An earlier attempt pinned 1.79.0, but that failed because `getrandom 0.4.2` (a transitive dependency in `Cargo.lock`) requires Rust edition 2024, which was stabilized in 1.85.0. So 1.85.0 is the minimum viable version.

**Not in this PR (already on `main`):** The "borrowed data escapes outside of function" borrow-checker error on macOS/Windows was resolved in a prior commit (v0.3.2 tag) — the v0.3.2 macOS and Windows CI builds already pass.

### Changes in this revision

- **Removed the pkg-config version override workaround** (from an earlier commit). Investigation confirmed the `webkit2gtk` crate's features are identical regardless of the reported system library version — the pkg-config override had no effect.
- **Root-caused the issue** to a glob-import trait-name collision: `gtk::prelude::SettingsExt` (for GTK settings) vs `webkit2gtk::SettingsExt` (for WebKit settings). Both are imported via `use gtk::prelude::*` and `use webkit2gtk::{traits::*, ...}` in `wry` v0.24.11. Recent Rust compilers no longer resolve trait methods when the trait name is ambiguous from two glob imports.
- **Adopted a two-toolchain approach**: stable for `tauri-cli` (which requires recent Rust to compile), and 1.85.0 for the actual project build (to avoid the trait collision). Previous single-toolchain pins (1.79.0) failed because `getrandom 0.4.2` needs edition 2024.

## Review & Testing Checklist for Human

- [ ] **Verify the Linux CI build passes with Rust 1.85.0.** This fix has **not yet been validated by a green CI run**. The exact Rust version that introduced the glob-import regression is unconfirmed — 1.85.0 may or may not be old enough. If it fails, try 1.86.0, 1.87.0, etc., or consider cargo-patching `wry` to add an explicit `use webkit2gtk::SettingsExt;` import.
- [ ] **Confirm macOS and Windows builds still pass.** They use `stable` and should be unaffected, but verify no regressions from the `RUSTUP_TOOLCHAIN` env var addition.
- [ ] **Evaluate Rust-pinning maintenance burden.** Pinning means the Linux build misses compiler improvements and security fixes. Long-term fix is migrating to Tauri v2 (tracked in #18).
- [ ] **Trigger the full auto-release pipeline** after merge: confirm the auto-tag workflow bumps the version, the Build & Release workflow runs on all 3 platforms, and a GitHub Release with artifacts is created (latest release is currently only v0.2.0).

**Suggested test plan:** After merge, trigger a `workflow_dispatch` on `main` to run the Build & Release workflow. Confirm all 3 platform builds succeed. Then tag a release to verify the full auto-release pipeline end-to-end.

### Notes
- The borrow error fix (`app_handle.state()` inside the spawned thread) is already present in both `W-A-I-T/EventBox` and `W-A-I-T/dance-flow-control` on their respective `main` branches. No additional code change is needed for that issue.
- `dance-flow-control` does not have its own Tauri build CI — it only has a sync trigger workflow. The build.yml fix is EventBox-specific.
- Tauri v2 migration is tracked in #18 — that is the proper long-term resolution.
- Requested by: @nightcrawlerxme
- [Link to Devin Session](https://app.devin.ai/sessions/4d3c3a7550624348a0ce82e12b194e4e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
