### PR TITLE
fix: fall back to direct squash merge when auto-merge is unavailable

### DIFF
--- a/.github/workflows/sync-danceflow.yml
+++ b/.github/workflows/sync-danceflow.yml
@@ -121,6 +121,10 @@ jobs:
 
       - name: Auto-merge sync PR
         if: steps.create-pr.outputs.pull-request-number
-        run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --auto
+        run: |
+          PR=${{ steps.create-pr.outputs.pull-request-number }}
+          # Try auto-merge first (requires branch protection with required checks).
+          # Fall back to an immediate squash merge when auto-merge is unavailable.
+          gh pr merge "$PR" --squash --auto || gh pr merge "$PR" --squash
         env:
           GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}


### PR DESCRIPTION
## Summary

The `sync-danceflow` workflow's auto-merge step was failing with:

```
GraphQL: Pull request Pull request is in clean status (enablePullRequestAutoMerge)
```

`gh pr merge --squash --auto` requires branch protection with required status checks to be configured. Since this repo doesn't have that, the PR is already in "clean" (mergeable) status and `--auto` has nothing to wait for, causing it to error out.

This fix tries `--auto` first and falls back to an immediate `--squash` merge if auto-merge isn't available, so the workflow works regardless of branch protection settings.

## Review & Testing Checklist for Human

- [ ] Verify the `||` fallback behavior is acceptable — if `--auto` fails for any reason (not just missing branch protection), it will attempt a direct merge. Confirm this is the desired behavior.
- [ ] After merging, trigger the `sync-danceflow` workflow manually (or wait for the next scheduled run) to confirm the merge step now succeeds end-to-end.

### Notes
- [Devin Session](https://app.devin.ai/sessions/736cb59aa99b40b182659a7716d3fe77)
- Requested by: @nightcrawlerxme