### PR TITLE
chore: auto-sync shared files from DanceFlowControl

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventbox-desktop"
-version = "0.3.4"
+version = "0.1.0"
 description = "EventBox — LAN Authority Server for dance competitions"
 authors = ["DanceFlowControl"]
 license = "MIT"
@@ -10,7 +10,7 @@ edition = "2021"
 tauri-build = { version = "1", features = [] }
 
 [dependencies]
-tauri = { version = "1", features = [ "process-all", "shell-open", "system-tray", "updater"] }
+tauri = { version = "1", features = ["process-all", "shell-open", "system-tray", "updater"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 local-ip-address = "0.6"


### PR DESCRIPTION
Automated sync of shared files from [DanceFlowControl](https://github.com/W-A-I-T/dance-flow-control).

**Changed files:**
```
desktop/src-tauri/Cargo.toml

```

> This PR was created automatically by the `sync-danceflow` workflow.
> DanceFlowControl is the source of truth for these files.