### PR TITLE
chore: bump version to 0.3.6 for e2e build test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventbox-desktop",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "EventBox — LAN Authority Server desktop app for dance competitions",
   "private": true,
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventbox-desktop"
-version = "0.3.5"
+version = "0.3.6"
 description = "EventBox — LAN Authority Server for dance competitions"
 authors = ["DanceFlowControl"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "EventBox",
-    "version": "0.3.5"
+    "version": "0.3.6"
   },
   "tauri": {
     "bundle": {


### PR DESCRIPTION
## Summary

Bumps version from `0.3.5` → `0.3.6` in all three version sources (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`).

The `v0.3.5` tag pointed to a broken build (Rust 1.85 / `time` crate incompatibility + malformed `TAURI_PRIVATE_KEY` secret). Those issues were fixed in PR #26. This version bump enables pushing a `v0.3.6` tag to verify the full signing pipeline end-to-end.

## Review & Testing Checklist for Human

- [ ] **After merging, push tag `v0.3.6` to trigger the build.** Verify all three platform builds succeed and produce `.sig` + `.tar.gz` artifacts.
- [ ] **Confirm `TAURI_PRIVATE_KEY` secret contains both lines** (the `untrusted comment:` line AND the base64 key). The v0.3.5 build failed with `Missing comment in secret key` on macOS/Windows.
- [ ] **Verify `latest.json`** is uploaded to the release with non-empty signatures and correct download URLs.

### Notes
- [Devin Session](https://app.devin.ai/sessions/736cb59aa99b40b182659a7716d3fe77)
- Requested by: @nightcrawlerxme