### PR TITLE
fix: use Tauri-signer-generated keypair for updater signing

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
     "updater": {
       "active": true,
       "dialog": true,
-      "pubkey": "RWTJEpWxUIpyfvDlEsM1mBhOMhfcBHoobUhUVuV9Uw4E3UWGK6G5bHSz",
+      "pubkey": "RWSB64F5e55Nx6hiKzS8AsWEB933xqNGwaKVS1HxVmFXwBWJh5lRUQak",
       "endpoints": [
         "https://github.com/W-A-I-T/EventBox/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
## Summary

Replaces the updater public key in `tauri.conf.json` with one generated by `npx @tauri-apps/cli signer generate` (Tauri's own key generator).

The previous key was generated with the `minisign` CLI, which outputs a raw two-line format (`untrusted comment:` + base64 key). Tauri v1 expects `TAURI_PRIVATE_KEY` to be the **base64-encoded content of the entire key file** (a single string), not the raw two-line format. This mismatch caused every build to fail at the signing step with:

```
Error incorrect updater private key password: Missing comment in secret key
```

## Review & Testing Checklist for Human

- [ ] **Update the `TAURI_PRIVATE_KEY` GitHub secret** with the new private key (provided separately). The old secret is incompatible with this new pubkey — builds will fail if only one side is updated.
- [ ] **Verify `TAURI_KEY_PASSWORD`** is set to an empty value (the new key was generated without a password).
- [ ] **After merging, push a new tag** (e.g. delete and re-push `v0.3.6`) and confirm all 3 platform builds pass the "Build Tauri app" step without the "Missing comment" error.
- [ ] **Update DanceFlowControl's `desktop/src-tauri/tauri.conf.json`** pubkey to match: `RWSB64F5e55Nx6hiKzS8AsWEB933xqNGwaKVS1HxVmFXwBWJh5lRUQak`

### Notes
- [Devin Session](https://app.devin.ai/sessions/736cb59aa99b40b182659a7716d3fe77)
- Requested by: @nightcrawlerxme