### PR TITLE
chore: bump version to 0.3.7 for e2e build test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventbox-desktop",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "EventBox — LAN Authority Server desktop app for dance competitions",
   "private": true,
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventbox-desktop"
-version = "0.3.6"
+version = "0.3.7"
 description = "EventBox — LAN Authority Server for dance competitions"
 authors = ["DanceFlowControl"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "EventBox",
-    "version": "0.3.6"
+    "version": "0.3.7"
   },
   "tauri": {
     "bundle": {


### PR DESCRIPTION
## Summary

Bumps version from `0.3.6` → `0.3.7` across all three version files (`package.json`, `Cargo.toml`, `tauri.conf.json`) to trigger a fresh build with the corrected Tauri-signer-generated signing key from PR #28.

Previous builds (v0.3.5, v0.3.6) all failed at the signing step because the `TAURI_PRIVATE_KEY` secret was in raw minisign format instead of Tauri's expected base64-encoded format. PR #28 fixed the pubkey; the secret has been updated by the repo owner.

## Review & Testing Checklist for Human

- [ ] Confirm all three version files read `0.3.7` (they do in this diff)
- [ ] After merging, push tag `v0.3.7` and verify all 3 platform builds pass the "Build Tauri app" step — this is the real test of whether the signing key fix works

### Notes
- [Devin Session](https://app.devin.ai/sessions/736cb59aa99b40b182659a7716d3fe77)
- Requested by: @nightcrawlerxme