### PR TITLE
fix: trigger auto-release for all pushes to main, not just auto-sync commits

### DIFF
--- a/.github/workflows/auto-release-on-sync.yml
+++ b/.github/workflows/auto-release-on-sync.yml
@@ -1,6 +1,7 @@
-name: Auto-release on sync
+name: Auto-release on push to main
 
-# Creates a new patch release whenever an auto-sync commit lands on main.
+# Creates a new patch release whenever a commit lands on main.
+# The version bump commit is excluded to prevent infinite loops.
 # The version bump commit + tag push triggers the existing Build & Release workflow.
 on:
   push:
@@ -9,10 +10,10 @@ on:
 
 jobs:
   auto-tag:
-    # Only run for auto-sync commits OR manual dispatch (prevents infinite loops from the version bump commit)
+    # Run for all pushes to main EXCEPT the version-bump commits this workflow creates (prevents infinite loops)
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.head_commit.message, 'chore: auto-sync')
+      !startsWith(github.event.head_commit.message, 'chore: bump version')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

The auto-release workflow (`auto-release-on-sync.yml`) previously only ran when commit messages started with `chore: auto-sync`, meaning **only** DanceFlowControl sync commits triggered new releases. Direct PRs merged to main (like #31 and #32) were silently skipped, leaving the latest release 2 versions behind.

**Root cause:** The `if` condition was an allowlist for sync commits:
```yaml
startsWith(github.event.head_commit.message, 'chore: auto-sync')
```

**Fix:** Inverted to a denylist that excludes only the version-bump commits this workflow itself creates (to prevent infinite loops):
```yaml
!startsWith(github.event.head_commit.message, 'chore: bump version')
```

Now any push to main — whether from auto-sync, direct PRs, or hotfixes — will trigger a patch release.

## Review & Testing Checklist for Human

- [ ] **Verify no infinite loop**: The version-bump commits use prefix `chore: bump version to vX.Y.Z` (line 74 of this file). Confirm `!startsWith(…, 'chore: bump version')` correctly excludes them. If this prefix ever changes, the exclusion breaks and you get an infinite loop of version bumps + pushes.
- [ ] **Confirm this is desired behavior**: Every push to main now creates a release, including non-code changes (docs, CI tweaks, skill files like PR #32). If you want to exclude certain commits, you may need path filters or additional conditions.
- [ ] **After merging, trigger a manual `workflow_dispatch`** on the workflow to catch up the 2 missing releases, or verify the merge commit itself triggers the workflow and produces a new tag + build.

### Notes
- This change cannot be validated by CI on the PR itself — the trigger condition only applies when commits land on `main`.
- The file was not renamed (still `auto-release-on-sync.yml`) to avoid breaking any external references, but the workflow `name` was updated to "Auto-release on push to main".