### PR TITLE
docs: remove remaining devin mention from EventBox skill

### DIFF
--- a/.agents/skills/testing-eventbox-server/SKILL.md
+++ b/.agents/skills/testing-eventbox-server/SKILL.md
@@ -145,5 +145,5 @@ Each server restart generates a new room code. Re-read it from stdout.
 - Fixes to `server.ts` must go into dance-flow-control first or they get overwritten by sync
 - Fixes to `lib.rs`, `Cargo.toml`, or other EventBox-only files go directly into EventBox
 
-## Devin Secrets Needed
+## Required Secrets
 None required for local server testing. The server generates its own HMAC secret on startup.


### PR DESCRIPTION
## Summary

- rename the leftover `Devin Secrets Needed` heading in the EventBox server testing skill
- keep the note itself intact while removing Devin-specific branding from tracked repo content

## Context

I also cleaned editable GitHub-side mentions separately by removing old Devin review badges and Claude/Devin footer lines from existing PR descriptions, and deleted the stale `devin/update-skills-1773629680` branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
