### PR TITLE
chore: Cleanup

### DIFF
--- a/.agents/skills/testing-eventbox-server/SKILL.md
+++ b/.agents/skills/testing-eventbox-server/SKILL.md
@@ -145,5 +145,5 @@ Each server restart generates a new room code. Re-read it from stdout.
 - Fixes to `server.ts` must go into dance-flow-control first or they get overwritten by sync
 - Fixes to `lib.rs`, `Cargo.toml`, or other EventBox-only files go directly into EventBox
 
-## Devin Secrets Needed
+## Required Secrets
 None required for local server testing. The server generates its own HMAC secret on startup.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/.github/workflows/auto-release-on-sync.yml
+++ b/.github/workflows/auto-release-on-sync.yml
@@ -70,8 +70,8 @@ jobs:
 
       - name: Commit version bump
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "nightcrawlerxme"
+          git config user.email "43687337+nightcrawlerxme@users.noreply.github.com"
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock src/index.html
           if ! git diff --cached --quiet; then
             git commit -m "chore: bump version to ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary

- Version-bump commits in `auto-release-on-sync.yml` now use `nightcrawlerxme`'s git identity instead of `github-actions[bot]`, so future releases no longer add the bot to the Contributors sidebar
- Added `.claude/settings.json` with `includeCoAuthoredBy: false` to suppress `Co-Authored-By: Claude` trailers, which were resolving to the `claude` GitHub account and adding it as a contributor

## What this doesn't fix

Existing 35 bot commits stay in history — a history rewrite (Phase 2) would be needed to remove them entirely, but that's a force-push to a public repo with 34 releases. This PR stops the bleeding going forward.

## Test plan

- [ ] Merge a trivial change to main after this lands → confirm version-bump commit appears under `nightcrawlerxme` in the commit list
- [ ] Check Contributors sidebar — `github-actions[bot]` and `claude` should stop accumulating new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/w-a-i-t/eventbox/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
